### PR TITLE
Update UploadDocuments to be virtual

### DIFF
--- a/src/Kentico.Xperience.AzureSearch/Indexing/BaseAzureSearchIndexingStrategy.cs
+++ b/src/Kentico.Xperience.AzureSearch/Indexing/BaseAzureSearchIndexingStrategy.cs
@@ -42,7 +42,7 @@ public class BaseAzureSearchIndexingStrategy<TSearchModel> : IAzureSearchIndexin
     public IList<SearchField> GetSearchFields() => fieldBuilder.Build(typeof(TSearchModel));
 
     /// <inheritdoc />
-    public async Task<int> UploadDocuments(IEnumerable<IAzureSearchModel> models, SearchClient searchClient)
+    public virtual async Task<int> UploadDocuments(IEnumerable<IAzureSearchModel> models, SearchClient searchClient)
     {
         var batch = new IndexDocumentsBatch<TSearchModel>();
 


### PR DESCRIPTION
# Motivation

Allows developers the ability to trigger various actions when a documents upload is made to Azure.

Our use case: We need to integrate with a 3rd party service to enrich a search index.
Whenever a full rebuild is triggered, we'd like to be able to also index data from a third party.
This currently is somewhat of a work-around since this will be triggered any time the index is updated.

Example usage:
```c#
public override async Task<int> UploadDocuments(IEnumerable<IAzureSearchModel> models, SearchClient searchClient)
{
    // additional logic before upload

    const uploadedDocuments = await base.UploadDocuments(models, searchClient);

    // additional logic after upload

    return uploadedDocuments;
}
```

## Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [ ] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

## How to test

Implement additional logic via the new virtual method.
See that original logic still functions as expected.
See that new logic is now invoked.
