### PR TITLE
KX-19639 - Update .gitignore with MCP server definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,8 @@ segments_2i
 **/App_Data/AzureAISearch/*
 /examples/DancingGoat/App_Data/CIRepository/DancingGoatEmails/cms.contentitemlanguagemetadata/dancinggoatsubscri..firmation-72wdczqk@6fd8c7a9fb/63bd3ac7-c0eb-477b-aaf0-52159ece6efc_en@a1ef42fb32.xml
 /examples/DancingGoat/App_Data/CIRepository/DancingGoatEmails/cms.contentitemlanguagemetadata
+
+# MCP server definitions
+mcp.json
+claude_desktop_config.json
+mcp_config.json


### PR DESCRIPTION
### Motivation
With the adoption of new IDEs there are also new config files that should (probably) not be commited to git. Focus was made on those with MCP server definitions, as there might be API keys to prod instances.
- mcp.json (VS Code, Cursor, JetBrains)
- claude_desktop_config.json (Claude)
- mcp_config.json (Windsurf)

To make sure nobody accidently commit those secrets in git, it was recommend adding those files to gitignore. If we see need to commit these files, team can later remove the .gitignore record, but also they must make sure there is no API keys in the file (e.g. use env variables).
